### PR TITLE
Add dependency graph and install order planning

### DIFF
--- a/R/deps_graph.R
+++ b/R/deps_graph.R
@@ -5,12 +5,14 @@
 #'   indicating whether the package as one of the roots used to create the
 #'   graph), "status" (installation status) and "order" (installation order).
 #'
+#' @importFrom miniCran makeDepGraph
+#' @importFrom igraph V
 dep_graph_create <- function(pkg, ...) {
-  statuses <- c("unavailable", "installing", "installed")
+  statuses <- c("pending", "installing", "installed")
   g <- miniCRAN::makeDepGraph(pkg, ...)
-  V(g)$root <- V(g)$name %in% pkg
-  V(g)$status <- factor("unavailable", levels = statuses)
-  g <- dep_graph_add_install_order(g)
+  igraph::V(g)$root <- igraph::V(g)$name %in% pkg
+  igraph::V(g)$status <- factor("pending", levels = statuses)
+  g <- dep_graph_update_install_order(g)
   g
 }
 
@@ -30,7 +32,7 @@ dep_graph_create <- function(pkg, ...) {
 #'   indicating the order in which dependencies should be installed.
 #'
 #' @importFrom igraph vertex_attr, neighborhood, subgraph.edges, topo_sort, E, V
-dep_graph_add_install_order <- function(g) {
+dep_graph_update_install_order <- function(g) {
   strong_deps <- c("Depends", "Imports", "LinkingTo")
   roots <- which(igraph::vertex_attr(g, "root"))
 


### PR DESCRIPTION
Filing as a PR in case you want to see my progress on this. It took a lot of trial and error to get things working properly, but I'm pretty happy with how straightforward the sorting ended up.

Found this wonderful `igraph::topo_sort` that does nearly exactly what we want. Given a set of packages, the fewest number of package installs required is used to prioritize which part of the graph we focus on, then we use the `topo_sort` to figure out a installation order.

"soft" dependencies (Suggests, Enhances) are ignored during `topo_sort` because it requires an acyclic graph.